### PR TITLE
Add feature and repair

### DIFF
--- a/include/ast/nodes/expressions.hpp
+++ b/include/ast/nodes/expressions.hpp
@@ -4,7 +4,7 @@
 #include "ast/nodes/expressions/call.hpp"
 #include "ast/nodes/expressions/member_access.hpp"
 #include "ast/nodes/expressions/comparation.hpp"
-#include "ast/nodes/expressions/logic_operation.hpp"
+#include "ast/nodes/expressions/logical.hpp"
 
 
 #include "ast/nodes/expressions/import.hpp"

--- a/include/ast/nodes/expressions/comparation.hpp
+++ b/include/ast/nodes/expressions/comparation.hpp
@@ -27,24 +27,13 @@ public:
 			{ LESS_EQUAL, L"≤" },
 		};
 
-		std::wstring result;
-		if (dynamic_cast<expr_entity*> (this->LEFT) != NULL) {
-			result += this->LEFT->view();
-		}
-		else {
-			result += L"(" + this->LEFT->view() + L")";
-		}
+		std::wstring result = L"(";
+		result += this->LEFT->view();
 
 		for (auto p : this->RIGHT) {
-			result += to_view[p.first];
-
-			if (dynamic_cast<expr_entity*> (p.second) != NULL) {
-				result += p.second->view();
-			}
-			else {
-				result += L"(" + p.second->view() + L")";
-			}
+			result += to_view[p.first] + p.second->view();
 		}
+		result += L")";
 
 		return result;
 	}

--- a/include/ast/nodes/expressions/expr.hpp
+++ b/include/ast/nodes/expressions/expr.hpp
@@ -47,15 +47,11 @@ public:
 			{ type::negative, L"-" },
 		};
 
-		std::wstring op;
-		if (dynamic_cast<expr_entity*> (this->OPERAND) != NULL) {
-			op = this->OPERAND->view();
-		}
-		else {
-			op = L"(" + this->OPERAND->view() + L")";
-		}
+		std::wstring result = L"(";
+		result += view_map[this->Type] + this->OPERAND->view();
+		result += L")";
 
-		return view_map[this->Type] + op;
+		return result;
 	}
 };
 
@@ -82,21 +78,10 @@ public:
 			{ type::division, L"/" },
 		};
 
-		std::wstring left, right;
-		if (dynamic_cast<expr_entity*> (this->OPERAND_LEFT) != NULL) {
-			left = this->OPERAND_LEFT->view();
-		}
-		else {
-			left = L"(" + this->OPERAND_LEFT->view() + L")";
-		}
-
-		if (dynamic_cast<expr_entity*> (this->OPERAND_RIGHT) != NULL) {
-			right = this->OPERAND_RIGHT->view();
-		}
-		else {
-			right = L"(" + this->OPERAND_RIGHT->view() + L")";
-		}
-		return left + view_map[this->Type] + right;
+		std::wstring result = L"(";
+		result += this->OPERAND_LEFT->view() + view_map[this->Type] + this->OPERAND_RIGHT->view();
+		result += L")";
+		return result;
 	}
 };
 

--- a/include/ast/nodes/expressions/logical.hpp
+++ b/include/ast/nodes/expressions/logical.hpp
@@ -41,3 +41,21 @@ public:
 };
 
 // NOT
+
+class logical_and : public expr {
+public:
+	logical_and(std::vector<expr*> items, int begin, int end) : expr(begin, end), items(items) {};
+
+	std::wstring view() {
+		std::wstring result = L"(";
+		for (expr* item : this->items) {
+			result += item->view() + L" && ";
+		}
+		result = result.substr(0, result.size()-4);
+		result += L")";
+		return result;
+	}
+
+private:
+	std::vector<expr*> items;
+};

--- a/include/ast/nodes/expressions/logical.hpp
+++ b/include/ast/nodes/expressions/logical.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-class expr_logic : public expr {
+/*class expr_logic : public expr {
 public:
 	enum class type {
 		AND,
@@ -38,9 +38,7 @@ public:
 
 		return left + to_view[this->SYM] + right;
 	}
-};
-
-// NOT
+};*/
 
 class logical_and : public expr {
 public:
@@ -58,4 +56,53 @@ public:
 
 private:
 	std::vector<expr*> items;
+};
+
+class logical_or : public expr {
+public:
+	logical_or(std::vector<expr*> items, int begin, int end) : expr(begin, end), items(items) {};
+
+	std::wstring view() {
+		std::wstring result = L"(";
+		for (expr* item : this->items) {
+			result += item->view() + L" || ";
+		}
+		result = result.substr(0, result.size()-4);
+		result += L")";
+		return result;
+	}
+
+private:
+	std::vector<expr*> items;
+};
+
+class logical_xor : public expr {
+public:
+	logical_xor(expr* left, expr* right, int begin, int end) : expr(begin, end), left(left), right(right) {};
+
+	std::wstring view() {
+		std::wstring result = L"(";
+		result += this->left->view() + L" \\\\ " + this->right->view();
+		result += L")";
+		return result;
+	}
+
+private:
+	expr* left;
+	expr* right;
+};
+
+class logical_not : public expr {
+public:
+	logical_not(expr* Expr, int begin, int end) : expr(begin, end), Expr(Expr) {};
+
+	std::wstring view() {
+		std::wstring result = L"(";
+		result += L"!" + this->Expr->view();
+		result += L")";
+		return result;
+	}
+
+private:
+	expr* Expr;
 };

--- a/include/parser/check.hpp
+++ b/include/parser/check.hpp
@@ -10,5 +10,5 @@ namespace check::symbol {
 };
 
 namespace check::keyword {
-	bool is(token* Token, token_symbol::type Type);
+	bool is(token* Token, token_keyword::type Type);
 };

--- a/include/parser/parse_logical.hpp
+++ b/include/parser/parse_logical.hpp
@@ -3,3 +3,4 @@
 #pragma once
 
 expr* parse_logical_and(token_list& Token_list);
+expr* parse_logical_or(token_list& Token_list);

--- a/include/parser/parse_logical.hpp
+++ b/include/parser/parse_logical.hpp
@@ -1,0 +1,5 @@
+#include "ast/nodes.hpp"
+
+#pragma once
+
+expr* parse_logical_and(token_list& Token_list);

--- a/include/tokens/tokens/symbol.hpp
+++ b/include/tokens/tokens/symbol.hpp
@@ -10,7 +10,7 @@ public:
 
 		AT,
 		QUESTION,
-		NOT, // !
+		NOT, // ! exclam
 		XOR,
 		AND, // AMPERSAND &
 		OR, // BAR |

--- a/include/tokens/tokens/symbol.hpp
+++ b/include/tokens/tokens/symbol.hpp
@@ -97,6 +97,9 @@ public:
 			{ token_symbol::type::AND, L"&" },
 			{ token_symbol::type::OR, L"|" },
 			{ token_symbol::type::XOR, L"\\" },
+			{ token_symbol::type::AND_AND, L"&&" },
+			{ token_symbol::type::OR_OR, L"||" },
+			{ token_symbol::type::XOR_XOR, L"\\\\" },
 
 
 			{ token_symbol::type::DOT, L"." },

--- a/src/parser/parse_expression.cpp
+++ b/src/parser/parse_expression.cpp
@@ -3,5 +3,5 @@
 #include "parser/parse_expression.hpp"
 
 expr* parse_expression(token_list& Token_list) {
-	return parse_logical_and(Token_list);
+	return parse_logical_or(Token_list);
 }

--- a/src/parser/parse_expression.cpp
+++ b/src/parser/parse_expression.cpp
@@ -1,6 +1,7 @@
-#include "parser/parse_comparation.hpp"
+#include "ast/nodes.hpp"
+#include "parser/parse_logical.hpp"
 #include "parser/parse_expression.hpp"
 
 expr* parse_expression(token_list& Token_list) {
-	return parse_comparation(Token_list);
+	return parse_logical_and(Token_list);
 }

--- a/src/parser/parse_if.cpp
+++ b/src/parser/parse_if.cpp
@@ -32,9 +32,14 @@ conditional_branches* parse_ifs(token_list& Token_list) {
 
 	while (true) {
 		if (check::symbol::is(Token_list.this_(), token_symbol::type::EOL_)) {
-			Token_list.next();
+			if (check::keyword::is(Token_list.peek(), token_keyword::type::ELSE_IF) || check::keyword::is(Token_list.peek(), token_keyword::type::ELSE)) {
+				Token_list.next();
+			}
+			else {
+				break;
+			}
 		}
-		else if (dynamic_cast<token_keyword*> (Token_list.this_()) != NULL && dynamic_cast<token_keyword*> (Token_list.this_())->Type == token_keyword::type::ELSE_IF) {
+		else if (check::keyword::is(Token_list.this_(), token_keyword::type::ELSE_IF)) {
 			Token_list.next();
 			result.push_back(parse_if(Token_list));
 		}
@@ -43,7 +48,7 @@ conditional_branches* parse_ifs(token_list& Token_list) {
 		}
 	}
 
-	if (dynamic_cast<token_keyword*> (Token_list.this_()) != NULL && dynamic_cast<token_keyword*> (Token_list.this_())->Type == token_keyword::type::ELSE) {
+	if (check::keyword::is(Token_list.this_(), token_keyword::type::ELSE)) {
 		Token_list.next();
 		result.push_back(parse_else(Token_list));
 	}

--- a/src/parser/parse_logical.cpp
+++ b/src/parser/parse_logical.cpp
@@ -1,0 +1,22 @@
+#include "parser/parse_logical.hpp"
+#include "ast/nodes.hpp"
+#include "parser/parse_comparation.hpp"
+#include "parser/check.hpp"
+
+expr* parse_logical_and(token_list& Token_list) {
+
+	expr* result = parse_comparation(Token_list);
+	if (check::symbol::is(Token_list.this_(), token_symbol::type::AND_AND)) {
+		std::vector<expr*> items;
+		items.push_back(result);
+
+		do {
+			Token_list.next();
+			items.push_back(parse_comparation(Token_list));
+		} while (check::symbol::is(Token_list.this_(), token_symbol::type::AND_AND));
+
+		result = new logical_and { items, 0, 0 };
+	}
+
+	return result;
+}

--- a/src/parser/parse_logical.cpp
+++ b/src/parser/parse_logical.cpp
@@ -20,3 +20,21 @@ expr* parse_logical_and(token_list& Token_list) {
 
 	return result;
 }
+
+expr* parse_logical_or(token_list& Token_list) {
+	expr* result = parse_logical_and(Token_list);
+
+	if (check::symbol::is(Token_list.this_(), token_symbol::type::OR_OR)) {
+		std::vector<expr*> items;
+		items.push_back(result);
+
+		do {
+			Token_list.next();
+			items.push_back(parse_logical_and(Token_list));
+		} while (check::symbol::is(Token_list.this_(), token_symbol::type::OR_OR));
+
+		result = new logical_or { items, 0, 0 };
+	}
+
+	return result;
+}

--- a/src/parser/parse_prefix.cpp
+++ b/src/parser/parse_prefix.cpp
@@ -1,6 +1,8 @@
 #include "parser/parse_prefix.hpp"
 #include "parser/parse_item.hpp"
 #include "parser/parse_arith.hpp"
+#include "parser/check.hpp"
+#include "parser/parse_comparation.hpp"
 
 expr* parse_prefix(token_list& Token_list) {
 	static std::map<token_type, unary_expr::type> unary_map = {
@@ -15,6 +17,12 @@ expr* parse_prefix(token_list& Token_list) {
 		auto val = parse_multi_divis(Token_list);
 		return new unary_expr { unary_map[first->TYPE], val, first->BEGIN, val->END };
 	}
+
+	else if (check::symbol::is(first, token_symbol::type::NOT)) {
+		Token_list.next();
+		return new logical_not { parse_comparation(Token_list), 0, 0 };
+	}
+
 	else {
 		return parse_miditem(Token_list);
 	}

--- a/src/parser/parse_statement.cpp
+++ b/src/parser/parse_statement.cpp
@@ -29,11 +29,11 @@ statement* parse_statement(token_list& Token_list) {
 		}
 
 		else if (keyword == token_keyword::type::ELSE_IF) {
-			throw L"'else if' without privious 'if'";
+			throw "'else if' without privious 'if'";
 		}
 
 		else if (keyword == token_keyword::type::ELSE) {
-			throw L"'else' without privious 'if'";
+			throw "'else' without privious 'if'";
 		}
 
 		else if (keyword == token_keyword::type::LOOP) {

--- a/src/parser/parse_statement.cpp
+++ b/src/parser/parse_statement.cpp
@@ -13,8 +13,7 @@ statement* parse_expr_statement(token_list& Token_list) {
 
 statement* parse_statement(token_list& Token_list) {
 	if (dynamic_cast<token_identifier*> (Token_list.this_()) != NULL && Token_list.peek()->TYPE == token_type::EQUAL) {
-		token_identifier* idn = dynamic_cast<token_identifier*> (Token_list.fetch()); // :=
-		// index += 2; // += -= ...
+		token_identifier* idn = dynamic_cast<token_identifier*> (Token_list.fetch());
 		Token_list.next();
 		expr* val = parse_expression(Token_list); // a = +1
 		return new defination { idn, val, idn->BEGIN, val->END };

--- a/src/parser/parse_statement_block.cpp
+++ b/src/parser/parse_statement_block.cpp
@@ -18,9 +18,10 @@ statement_block* parse_statements(token_list& Token_list, token_type terminator)
 			statement_list.push_back(parse_statement(Token_list));
 
 			if (Token_list.this_()->TYPE != token_type::SEMICOLON &&
-				Token_list.this_()->TYPE != token_type::EOL_       &&
+				Token_list.this_()->TYPE != token_type::EOL_      &&
 				Token_list.this_()->TYPE != terminator) {
 
+				if(dynamic_cast<token_keyword*>(Token_list.this_())!=NULL) throw 1;
 				throw new unexpect_token {2,1}; // expect semicolon, eol or }.
 			}
 		}

--- a/src/parser/parse_statement_block.cpp
+++ b/src/parser/parse_statement_block.cpp
@@ -21,7 +21,7 @@ statement_block* parse_statements(token_list& Token_list, token_type terminator)
 				Token_list.this_()->TYPE != token_type::EOL_       &&
 				Token_list.this_()->TYPE != terminator) {
 
-				throw new unexpect_token {2,1};
+				throw new unexpect_token {2,1}; // expect semicolon, eol or }.
 			}
 		}
 

--- a/src/scanner/scanner.cpp
+++ b/src/scanner/scanner.cpp
@@ -94,6 +94,9 @@ std::map<token_type, token_symbol::type> new_symbol_map = {
 	{ token_type::NOT, token_symbol::type::NOT },
 	{ token_type::AND, token_symbol::type::AND },
 	{ token_type::OR, token_symbol::type::OR },
+	{ token_type::AND_AND, token_symbol::type::AND_AND },
+	{ token_type::OR_OR, token_symbol::type::OR_OR },
+	{ token_type::XOR_XOR, token_symbol::type::XOR_XOR },
 
 	{ token_type::PLUS, token_symbol::type::PLUS },
 	{ token_type::MINUS, token_symbol::type::MINUS },
@@ -145,6 +148,9 @@ trie<token_type> symbol_map = {
 	{ L"&", token_type::AND },
 	{ L"|", token_type::OR },
 	{ L"\\", token_type::XOR },
+	{ L"&&", token_type::AND_AND },
+	{ L"||", token_type::OR_OR },
+	{ L"\\\\", token_type::XOR_XOR },
 
 	{ L"+", token_type::PLUS },
 	{ L"-", token_type::MINUS },


### PR DESCRIPTION
- simplify ast view
- add support for logical_and `&&` and logical_or `||`
- repair error: any token except token_keyword::ELSE below IF_STATEMENT will raise error.