### PR TITLE
Cut convertation between token_type(old) and token_symbol::type(new).

### DIFF
--- a/include/parser/parse_statement_block.hpp
+++ b/include/parser/parse_statement_block.hpp
@@ -1,5 +1,5 @@
 #pragma once
 
-statement_block* parse_statements(token_list& Token_list, token_type terminator); // temp
+statement_block* parse_statements(token_list& Token_list, token_symbol::type terminator); // temp
 
 statement_block* parse_statement_block(token_list& Token_list);

--- a/include/tokens/tokens/entity.hpp
+++ b/include/tokens/tokens/entity.hpp
@@ -2,13 +2,13 @@
 
 class token_entity : public token {
 public:
-	token_entity(token_type type, int begin, int end) : token(type, begin, end) {};
+	token_entity(int begin, int end) : token(begin, end) {};
 };
 
 class token_identifier : public token_entity {
 public:
 	std::wstring VALUE; // name
-	token_identifier(std::wstring value, int begin, int end) : token_entity(token_type::temp, begin, end), VALUE(value) {};
+	token_identifier(std::wstring value, int begin, int end) : token_entity(begin, end), VALUE(value) {};
 
 	std::wstring view() {
 		return this->VALUE;
@@ -17,7 +17,7 @@ public:
 
 class token_literal : public token_entity {
 public:
-	token_literal(int begin, int end) : token_entity(token_type::temp, begin, end) {};
+	token_literal(int begin, int end) : token_entity(begin, end) {};
 };
 
 class token_number : public token_literal {

--- a/include/tokens/tokens/keyword.hpp
+++ b/include/tokens/tokens/keyword.hpp
@@ -24,7 +24,7 @@ public:
 	};
 
 	type Type;
-	token_keyword(type Type, int begin, int end) : token(token_type::temp, begin, end), Type(Type) {};
+	token_keyword(type Type, int begin, int end) : token(begin, end), Type(Type) {};
 
 	std::wstring view() {
 

--- a/include/tokens/tokens/symbol.hpp
+++ b/include/tokens/tokens/symbol.hpp
@@ -75,7 +75,7 @@ public:
 	};
 
 	type Type;
-	token_symbol(token_type type_, type Type, int begin, int end) : token(type_, begin, end), Type(Type) {};
+	token_symbol(type Type, int begin, int end) : token(begin, end), Type(Type) {};
 
 	std::wstring view() {
 		static std::map<token_symbol::type, std::wstring> token_to_view = {

--- a/include/tokens/tokens/token.hpp
+++ b/include/tokens/tokens/token.hpp
@@ -5,100 +5,10 @@
 #include <vector>
 
 
-enum class token_type {
-
-	temp,
-
-	// operators
-
-	AT,
-
-	QUESTION,
-	NOT, // !
-	XOR,
-	AND, // AMPERSAND &
-	OR, // BAR |
-
-	BIT_INVERSION, // *!
-	BIT_AND,       // *&
-	BIT_XOR,       
-	BIT_OR,        // *|
-
-
-	PLUS,         // + 
-	MINUS,        // -
-	ASTERISK,     // *
-	SLASH,        // /
-	CARET,        // ^
-	CARET_SLASH,  // ^/
-	PERCENT,      // %
-
-	/// comparision operators
-	GREATER,          // >
-	LESS,             // <
-	GREATER_EQUAL,    // >=
-	LESS_EQUAL,       // <=
-	EQUAL_EQUAL,      // ==
-	NOT_EQUAL,        // !==
-	IDENTICAL,        // ===
-	NOT_IDENTICAL,    // !=== identity
-	// !> !< !>= ...
-
-	/// logical operators
-	NOT_NOT, // !!
-	AND_AND, // &&
-	XOR_XOR,
-	OR_OR,   // ||
-
-	/// relational operators emm
-	BELONG,           // ->
-	SUB,     // =>
-	NOT_BELONG,       // !->
-	NOT_SUB, // !=>
-
-	/// assign ops
-	EQUAL,             // =
-	PLUS_EQUAL,        // +=
-	MINUS_EQUAL,       // -=
-	ASTERISK_EQUAL,    // *=
-	SLASH_EQUAL,       // /=
-	CARET_EQUAL,       // ^=
-	CARET_SLASH_EQUAL, // ^/=
-	PERCENT_EQUAL,     // %=
-
-
-	AT_EQUAL, // @=
-
-	TILDE, //
-
-
-	// seperators
-	BOF_,
-	EOL_,
-	EOF_,
-
-	COMMA,     // ,
-	DOT,       // .
-	COLON,     // :
-	SEMICOLON, // ;
-
-	OPEN_PAREN,    // (
-	CLOSE_PAREN,   // )
-	OPEN_BRACKET,  // [
-	CLOSE_BRACKET, // ]
-	OPEN_BRACE,    // {
-	CLOSE_BRACE,   // }
-
-	DOUBLE_ANGLE_BRACKET_LEFT,  // <<
-	DOUBLE_ANGLE_BRACKET_RIGHT, // >>
-
-};
-
 class token {
 public:
-	token_type TYPE;
 	int BEGIN, END;
-	token(token_type type, int begin, int end) : TYPE(type), BEGIN(begin), END(end) {};
+	token(int begin, int end) : BEGIN(begin), END(end) {};
 
 	virtual std::wstring view() {
 		return this->view();

--- a/include/tokens/tokens/token.hpp
+++ b/include/tokens/tokens/token.hpp
@@ -33,10 +33,6 @@ enum class token_type {
 	CARET_SLASH,  // ^/
 	PERCENT,      // %
 
-	// POSITIVE,
-	// NEGATIVE, ;; chinese -x 'fu' and x-y 'jian' diff in lex
-
-
 	/// comparision operators
 	GREATER,          // >
 	LESS,             // <

--- a/src/parser/parse_comparation.cpp
+++ b/src/parser/parse_comparation.cpp
@@ -4,33 +4,43 @@
 
 #include "ast/nodes.hpp"
 
-expr* parse_comparation(token_list& Token_list) {
+std::map<token_symbol::type, comparation::type> comp_symbol_map = {
+	{ token_symbol::type::EQUAL_EQUAL, comparation::EQUAL },
+	{ token_symbol::type::GREATER, comparation::GREATER },
+	{ token_symbol::type::LESS, comparation::LESS },
+	{ token_symbol::type::NOT_EQUAL, comparation::NOT_EQUAL },
+	{ token_symbol::type::GREATER_EQUAL, comparation::GREATER_EQUAL },
+	{ token_symbol::type::LESS_EQUAL, comparation::LESS_EQUAL },
+};
 
-	static std::map<token_type, comparation::type> map = {
-		{ token_type::EQUAL_EQUAL, comparation::EQUAL },
-		{ token_type::GREATER, comparation::GREATER },
-		{ token_type::LESS, comparation::LESS },
-		{ token_type::NOT_EQUAL, comparation::NOT_EQUAL },
-		{ token_type::GREATER_EQUAL, comparation::GREATER_EQUAL },
-		{ token_type::LESS_EQUAL, comparation::LESS_EQUAL },
-	};
+bool is_comp_symbol(token* Token) {
+	bool result = false;
+	if (dynamic_cast<token_symbol*> (Token) != NULL) {
+		token_symbol* _Token = dynamic_cast<token_symbol*> (Token); //！
+		if (comp_symbol_map.find(_Token->Type) != comp_symbol_map.end()) {
+			result = true;
+		}
+	}
+	return result;
+}
+
+expr* parse_comparation(token_list& Token_list) {
 	expr* result;
 	expr* left;
 
 	result = parse_arith(Token_list);
 
 	// token_symbol::type
-	if (map.find(Token_list.this_()->TYPE) != map.end()) {
+	if (is_comp_symbol(Token_list.this_())) {
 		expr* left = result;
 		std::vector<std::pair<comparation::type, expr*>> right;
 
 		do {
-			comparation::type comp_type = map[Token_list.this_()->TYPE];
-			Token_list.next();
+			comparation::type comp_type = comp_symbol_map[dynamic_cast<token_symbol*> (Token_list.fetch()) -> Type];
 
 			expr* comp_item = parse_arith(Token_list);
 			right.push_back({ comp_type, comp_item });
-		} while (map.find(Token_list.this_()->TYPE) != map.end());
+		} while (is_comp_symbol(Token_list.this_()));
 
 		result = new comparation { left, right, left->BEGIN, right.back().second->END };
 	}

--- a/src/parser/parse_prefix.cpp
+++ b/src/parser/parse_prefix.cpp
@@ -3,19 +3,21 @@
 #include "parser/parse_arith.hpp"
 #include "parser/check.hpp"
 #include "parser/parse_comparation.hpp"
+#include "parser/check.hpp"
 
 expr* parse_prefix(token_list& Token_list) {
-	static std::map<token_type, unary_expr::type> unary_map = {
-		{ token_type::PLUS, unary_expr::type::positive },
-		{ token_type::MINUS, unary_expr::type::negative },
-	};
-
 	token* first = Token_list.this_();
 
-	if (unary_map.find(first->TYPE) != unary_map.end()) {
+	if (check::symbol::is(first, token_symbol::type::PLUS)) {
 		Token_list.next();
 		auto val = parse_multi_divis(Token_list);
-		return new unary_expr { unary_map[first->TYPE], val, first->BEGIN, val->END };
+		return new unary_expr { unary_expr::type::positive, val, first->BEGIN, val->END };
+	}
+
+	else if (check::symbol::is(first, token_symbol::type::MINUS)) {
+		Token_list.next();
+		auto val = parse_multi_divis(Token_list);
+		return new unary_expr { unary_expr::type::negative, val, first->BEGIN, val->END };
 	}
 
 	else if (check::symbol::is(first, token_symbol::type::NOT)) {

--- a/src/parser/parse_statement.cpp
+++ b/src/parser/parse_statement.cpp
@@ -4,6 +4,7 @@
 
 #include "parser/parse_if.hpp"
 #include "parser/loop/parse_loop.hpp"
+#include "parser/check.hpp"
 
 
 statement* parse_expr_statement(token_list& Token_list) {
@@ -12,7 +13,7 @@ statement* parse_expr_statement(token_list& Token_list) {
 }
 
 statement* parse_statement(token_list& Token_list) {
-	if (dynamic_cast<token_identifier*> (Token_list.this_()) != NULL && Token_list.peek()->TYPE == token_type::EQUAL) {
+	if (dynamic_cast<token_identifier*> (Token_list.this_()) != NULL && check::symbol::is(Token_list.peek(), token_symbol::type::EQUAL)) {
 		token_identifier* idn = dynamic_cast<token_identifier*> (Token_list.fetch());
 		Token_list.next();
 		expr* val = parse_expression(Token_list); // a = +1

--- a/src/parser/parse_statement_block.cpp
+++ b/src/parser/parse_statement_block.cpp
@@ -2,28 +2,28 @@
 #include "parser/parse_statement_block.hpp"
 #include "parser/parse_statement.hpp"
 #include "exceptions/syntax_errors.hpp"
+#include "parser/check.hpp"
 
-
-statement_block* parse_statements(token_list& Token_list, token_type terminator) {
+statement_block* parse_statements(token_list& Token_list, token_symbol::type terminator) {
 	std::vector<statement*> statement_list;
 	int begin = Token_list.this_()->BEGIN;
 
-	while (Token_list.this_()->TYPE != terminator) {
+	while (!check::symbol::is(Token_list.this_(), terminator)) {
 
-		if (Token_list.this_()->TYPE == token_type::SEMICOLON || Token_list.this_()->TYPE == token_type::EOL_) {
+		if (check::symbol::is(Token_list.this_(), token_symbol::type::SEMICOLON) || check::symbol::is(Token_list.this_(), token_symbol::type::EOL_)) {
 			Token_list.next();
 		}
 
 		else {
 			statement_list.push_back(parse_statement(Token_list));
 
-			if (Token_list.this_()->TYPE != token_type::SEMICOLON &&
-				Token_list.this_()->TYPE != token_type::EOL_      &&
-				Token_list.this_()->TYPE != terminator) {
+			if (!check::symbol::is(Token_list.this_(), token_symbol::type::SEMICOLON) &&
+				!check::symbol::is(Token_list.this_(), token_symbol::type::EOL_)      &&
+				!check::symbol::is(Token_list.this_(), terminator)) {
 
-				if(dynamic_cast<token_keyword*>(Token_list.this_())!=NULL) throw 1;
 				throw new unexpect_token {2,1}; // expect semicolon, eol or }.
 			}
+			// check::symbol::require({A,B,C})
 		}
 
 	}
@@ -33,5 +33,5 @@ statement_block* parse_statements(token_list& Token_list, token_type terminator)
 }
 
 statement_block* parse_statement_block(token_list& Token_list) {
-	return parse_statements(Token_list, token_type::CLOSE_BRACE);
+	return parse_statements(Token_list, token_symbol::type::BRACE_RIGHT);
 }

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -11,7 +11,7 @@ statement_block* parse_exe(std::wstring filepath) { // parse main program
 	int index = 1; // pass BOF
 	Token_list.fetch();
 	
-	return parse_statements(Token_list, token_type::EOF_);
+	return parse_statements(Token_list, token_symbol::type::EOF_);
 }
 
 

--- a/src/scanner/scanner.cpp
+++ b/src/scanner/scanner.cpp
@@ -87,135 +87,85 @@ std::map<std::wstring, bool> literal_bool_map = {
 
 };*/
 
-std::map<token_type, token_symbol::type> new_symbol_map = {
 
-	{ token_type::AT, token_symbol::type::AT },
-	{ token_type::QUESTION, token_symbol::type::QUESTION },
-	{ token_type::NOT, token_symbol::type::NOT },
-	{ token_type::AND, token_symbol::type::AND },
-	{ token_type::OR, token_symbol::type::OR },
-	{ token_type::AND_AND, token_symbol::type::AND_AND },
-	{ token_type::OR_OR, token_symbol::type::OR_OR },
-	{ token_type::XOR_XOR, token_symbol::type::XOR_XOR },
-
-	{ token_type::PLUS, token_symbol::type::PLUS },
-	{ token_type::MINUS, token_symbol::type::MINUS },
-	{ token_type::ASTERISK, token_symbol::type::ASTERISK },
-	{ token_type::SLASH, token_symbol::type::SLASH },
-	{ token_type::PERCENT, token_symbol::type::PERCENT },
-
-
-	{ token_type::DOT, token_symbol::type::DOT },
-	{ token_type::COMMA, token_symbol::type::COMMA },
-	{ token_type::COLON, token_symbol::type::COLON },
-	{ token_type::SEMICOLON, token_symbol::type::SEMICOLON },
-	{ token_type::OPEN_PAREN, token_symbol::type::PAREN_LEFT },
-	{ token_type::CLOSE_PAREN, token_symbol::type::PAREN_RIGHT },
-	{ token_type::OPEN_BRACKET, token_symbol::type::BRACKET_LEFT },
-	{ token_type::CLOSE_BRACKET, token_symbol::type::BRACKET_RIGHT },
-	{ token_type::OPEN_BRACE, token_symbol::type::BRACE_LEFT },
-	{ token_type::CLOSE_BRACE, token_symbol::type::BRACE_RIGHT },
-	{ token_type::DOUBLE_ANGLE_BRACKET_LEFT, token_symbol::type::ANGLE_BRACKET_LEFT },
-	{ token_type::DOUBLE_ANGLE_BRACKET_RIGHT, token_symbol::type::ANGLE_BRACKET_RIGHT },
-
-	{ token_type::GREATER, token_symbol::type::GREATER },
-	{ token_type::LESS, token_symbol::type::LESS },
-	{ token_type::GREATER_EQUAL, token_symbol::type::GREATER_EQUAL },
-	{ token_type::LESS_EQUAL, token_symbol::type::LESS_EQUAL },
-	{ token_type::EQUAL_EQUAL, token_symbol::type::EQUAL_EQUAL },
-	{ token_type::NOT_EQUAL, token_symbol::type::NOT_EQUAL },
-
-	{ token_type::BELONG, token_symbol::type::SINGLE_ARROW },
-	{ token_type::SUB, token_symbol::type::DOUBLE_ARROW },
-	// { L"!=>", token_symbol::type::NOT_SUB },
-
-	{ token_type::EQUAL, token_symbol::type::EQUAL },
-	{ token_type::PLUS_EQUAL, token_symbol::type::PLUS_EQUAL },
-	{ token_type::MINUS_EQUAL, token_symbol::type::MINUS_EQUAL },
-	{ token_type::ASTERISK_EQUAL, token_symbol::type::ASTERISK_EQUAL },
-	{ token_type::SLASH_EQUAL, token_symbol::type::SLASH_EQUAL },
-	// { token_type::CARET_EQUAL, token_symbol::type::CARET_EQUAL },
-	{ token_type::PERCENT_EQUAL, token_symbol::type::PERCENT_EQUAL },
-};
-
-trie<token_type> symbol_map = {
+trie<token_symbol::type> symbol_map = {
 
 // 通用
 
-	{ L"@", token_type::AT },
-	{ L"?", token_type::QUESTION },
-	{ L"!", token_type::NOT },
-	{ L"&", token_type::AND },
-	{ L"|", token_type::OR },
-	{ L"\\", token_type::XOR },
-	{ L"&&", token_type::AND_AND },
-	{ L"||", token_type::OR_OR },
-	{ L"\\\\", token_type::XOR_XOR },
+	{ L"@", token_symbol::type::AT },
+	{ L"?", token_symbol::type::QUESTION },
+	{ L"!", token_symbol::type::NOT },
+	{ L"&", token_symbol::type::AND },
+	{ L"|", token_symbol::type::OR },
+	{ L"\\", token_symbol::type::XOR },
+	{ L"&&", token_symbol::type::AND_AND },
+	{ L"||", token_symbol::type::OR_OR },
+	{ L"\\\\", token_symbol::type::XOR_XOR },
 
-	{ L"+", token_type::PLUS },
-	{ L"-", token_type::MINUS },
-	{ L"*", token_type::ASTERISK },
-	{ L"/", token_type::SLASH },
-	{ L"^", token_type::CARET },
-	{ L"^/", token_type::CARET_SLASH },
-	{ L"%", token_type::PERCENT },
+	{ L"+", token_symbol::type::PLUS },
+	{ L"-", token_symbol::type::MINUS },
+	{ L"*", token_symbol::type::ASTERISK },
+	{ L"/", token_symbol::type::SLASH },
+	{ L"^", token_symbol::type::CARET },
+	{ L"^/", token_symbol::type::CARET_SLASH },
+	{ L"%", token_symbol::type::PERCENT },
 
 
-	{ L".", token_type::DOT },
-	{ L",", token_type::COMMA },
-	{ L":", token_type::COLON },
-	{ L";", token_type::SEMICOLON },
-	{ L"(", token_type::OPEN_PAREN },
-	{ L")", token_type::CLOSE_PAREN },
-	{ L"[", token_type::OPEN_BRACKET },
-	{ L"]", token_type::CLOSE_BRACKET },
-	{ L"{", token_type::OPEN_BRACE },
-	{ L"}", token_type::CLOSE_BRACE },
-	{ L"<<", token_type::DOUBLE_ANGLE_BRACKET_LEFT },
-	{ L">>", token_type::DOUBLE_ANGLE_BRACKET_RIGHT },
+	{ L".", token_symbol::type::DOT },
+	{ L",", token_symbol::type::COMMA },
+	{ L":", token_symbol::type::COLON },
+	{ L";", token_symbol::type::SEMICOLON },
+	{ L"(", token_symbol::type::PAREN_LEFT },
+	{ L")", token_symbol::type::PAREN_RIGHT },
+	{ L"[", token_symbol::type::BRACKET_LEFT },
+	{ L"]", token_symbol::type::BRACKET_RIGHT },
+	{ L"{", token_symbol::type::BRACE_LEFT },
+	{ L"}", token_symbol::type::BRACE_RIGHT },
+	{ L"<<", token_symbol::type::ANGLE_BRACKET_LEFT },
+	{ L">>", token_symbol::type::ANGLE_BRACKET_RIGHT },
 
-	{ L">", token_type::GREATER },
-	{ L"<", token_type::LESS },
-	{ L">=", token_type::GREATER_EQUAL },
-	{ L"≥", token_type::GREATER_EQUAL },
-	{ L"<=", token_type::LESS_EQUAL },
-	{ L"≤", token_type::LESS_EQUAL },
-	{ L"==", token_type::EQUAL_EQUAL },
-	{ L"!=", token_type::NOT_EQUAL },
-	{ L"≠", token_type::NOT_EQUAL },
+	{ L">", token_symbol::type::GREATER },
+	{ L"<", token_symbol::type::LESS },
+	{ L">=", token_symbol::type::GREATER_EQUAL },
+	{ L"≥", token_symbol::type::GREATER_EQUAL },
+	{ L"<=", token_symbol::type::LESS_EQUAL },
+	{ L"≤", token_symbol::type::LESS_EQUAL },
+	{ L"==", token_symbol::type::EQUAL_EQUAL },
+	{ L"!=", token_symbol::type::NOT_EQUAL },
+	{ L"≠", token_symbol::type::NOT_EQUAL },
 
-	{ L"->", token_type::BELONG },
-	{ L"=>", token_type::SUB },
-	{ L"!->", token_type::NOT_BELONG },
-	{ L"!=>", token_type::NOT_SUB },
+	{ L"->", token_symbol::type::SINGLE_ARROW },
+	{ L"=>", token_symbol::type::DOUBLE_ARROW },
+/*	{ L"!->", token_symbol::type::NOT_BELONG },
+	{ L"!=>", token_symbol::type::NOT_SUB },*/
 
-	{ L"=", token_type::EQUAL },
-	{ L"+=", token_type::PLUS_EQUAL },
-	{ L"-=", token_type::MINUS_EQUAL },
-	{ L"*=", token_type::ASTERISK_EQUAL },
-	{ L"/=", token_type::SLASH_EQUAL },
-	{ L"^=", token_type::CARET_EQUAL },
-	{ L"^/=", token_type::CARET_SLASH_EQUAL },
-	{ L"%=", token_type::PERCENT_EQUAL },
+	{ L"=", token_symbol::type::EQUAL },
+	{ L"+=", token_symbol::type::PLUS_EQUAL },
+	{ L"-=", token_symbol::type::MINUS_EQUAL },
+	{ L"*=", token_symbol::type::ASTERISK_EQUAL },
+	{ L"/=", token_symbol::type::SLASH_EQUAL },
+	{ L"^=", token_symbol::type::CARET_EQUAL },
+	{ L"^/=", token_symbol::type::CARET_SLASH_EQUAL },
+	{ L"%=", token_symbol::type::PERCENT_EQUAL },
 
 // zh-cn
-	{ L"？", token_type::QUESTION },
-	{ L"！", token_type::NOT },
+	{ L"？", token_symbol::type::QUESTION },
+	{ L"！", token_symbol::type::NOT },
 
-	{ L"，", token_type::COMMA },
-	{ L"：", token_type::COLON },
-	{ L"；", token_type::SEMICOLON },
-	{ L"（", token_type::OPEN_PAREN },
-	{ L"）", token_type::CLOSE_PAREN },
-	{ L"【", token_type::OPEN_BRACKET },
-	{ L"】", token_type::CLOSE_BRACKET },
-	{ L"｛", token_type::OPEN_BRACE },
-	{ L"｝", token_type::CLOSE_BRACE },
-	{ L"《", token_type::DOUBLE_ANGLE_BRACKET_LEFT },
-	{ L"》", token_type::DOUBLE_ANGLE_BRACKET_RIGHT },
+	{ L"，", token_symbol::type::COMMA },
+	{ L"：", token_symbol::type::COLON },
+	{ L"；", token_symbol::type::SEMICOLON },
+	{ L"（", token_symbol::type::PAREN_LEFT },
+	{ L"）", token_symbol::type::PAREN_RIGHT },
+	{ L"【", token_symbol::type::BRACKET_LEFT },
+	{ L"】", token_symbol::type::BRACKET_RIGHT },
+	{ L"｛", token_symbol::type::BRACE_LEFT },
+	{ L"｝", token_symbol::type::BRACE_RIGHT },
+	{ L"《", token_symbol::type::ANGLE_BRACKET_LEFT },
+	{ L"》", token_symbol::type::ANGLE_BRACKET_RIGHT },
 
-	{ L"！->", token_type::NOT_BELONG },
-	{ L"！=>", token_type::NOT_SUB }, // replace_list
+/*	{ L"！->", token_symbol::type::NOT_BELONG },
+	{ L"！=>", token_symbol::type::NOT_SUB }, // replace_list*/
 
 };
 
@@ -229,7 +179,7 @@ token_list scan(std::wstring filepath) {
 	std::vector<token*> Token_list;
 	std::wstring src = read(filepath, coding::UTF_8);
 
-	Token_list.push_back(new token_symbol {token_type::BOF_, token_symbol::type::BOF_, 0, 0});
+	Token_list.push_back(new token_symbol {token_symbol::type::BOF_, 0, 0});
 
 	int length = src.length();
 
@@ -267,7 +217,7 @@ token_list scan(std::wstring filepath) {
 			do {
 				i += 1;				
 			} while (src[i] == L'\u000A' || src[i] == L'\u000D' || src[i] == L'\u0085');
-			Token_list.push_back(new token_symbol {token_type::EOL_, token_symbol::type::EOL_, begin, i});
+			Token_list.push_back(new token_symbol {token_symbol::type::EOL_, begin, i});
 		}
 
 		// escape
@@ -333,7 +283,7 @@ token_list scan(std::wstring filepath) {
 
 		// token.symbol
 		else if (auto val = symbol_map.search(src, i)) {
-			Token_list.push_back(new token_symbol { *val, new_symbol_map[*val], begin, i });
+			Token_list.push_back(new token_symbol { *val, begin, i });
 		}
 
 		else {
@@ -342,7 +292,7 @@ token_list scan(std::wstring filepath) {
 
 	}
 
-	Token_list.push_back(new token_symbol {token_type::EOF_, token_symbol::type::EOF_, length, length});
+	Token_list.push_back(new token_symbol {token_symbol::type::EOF_, length, length});
 	return token_list { Token_list };
 
 }

--- a/src/scanner/scanner.cpp
+++ b/src/scanner/scanner.cpp
@@ -264,10 +264,10 @@ token_list scan(std::wstring filepath) {
 
 		// EOL
 		else if (src[i] == L'\u000A' || src[i] == L'\u000D' || src[i] == L'\u0085') { // LF || CR || NEL
-			if (Token_list.back()->TYPE != token_type::EOL_) {
-				Token_list.push_back(new token_symbol {token_type::EOL_, token_symbol::type::EOL_, begin, i});
-			}
-			i += 1;
+			do {
+				i += 1;				
+			} while (src[i] == L'\u000A' || src[i] == L'\u000D' || src[i] == L'\u0085');
+			Token_list.push_back(new token_symbol {token_type::EOL_, token_symbol::type::EOL_, begin, i});
 		}
 
 		// escape


### PR DESCRIPTION
Simplify the procedure while scanning.
- remove old api using.
- remove token_type definition.